### PR TITLE
Add conditional localization import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0-preview.0] - 2021-9-14
+### Changed
+- Added *conditional* localization attribute definiion. Fixes editor script import on 2020.3 while preserving functions on 2019.4.
+
 ## [1.1.0] - 2019-10-31
 *This is the first version of UnityChan Spring Bone in the package form.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.2.0-preview.0] - 2021-9-14
+## [1.2.1-preview.0] - 2021-9-14
 ### Changed
-- Added *conditional* localization attribute definiion. Fixes editor script import on 2020.3 while preserving functions on 2019.4.
+- Added *conditional* localization attribute definition. Fixes editor script import on 2020.3 while preserving functions on 2019.4.
 
 ## [1.1.0] - 2019-10-31
 *This is the first version of UnityChan Spring Bone in the package form.*

--- a/Editor/AssmblyInfo.cs
+++ b/Editor/AssmblyInfo.cs
@@ -1,3 +1,7 @@
-﻿using UnityEditor.Localization.Editor;
+﻿#if UNITY_2020_1_OR_NEWER
+using Localization = UnityEditor.LocalizationAttribute;
+#else
+using Localization = UnityEditor.Localization.Editor.LocalizationAttribute;
+#endif
  
 [assembly: Localization]

--- a/Editor/AutoSpringBoneSetup.cs
+++ b/Editor/AutoSpringBoneSetup.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/GUI/Windows/LoadSpringBoneSetupWindow.cs
+++ b/Editor/GUI/Windows/LoadSpringBoneSetupWindow.cs
@@ -1,7 +1,11 @@
 ﻿using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/GUI/Windows/MirrorSpringBoneWindow.cs
+++ b/Editor/GUI/Windows/MirrorSpringBoneWindow.cs
@@ -3,7 +3,11 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Unity.Animations.SpringBones.GameObjectExtensions;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
+++ b/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
@@ -2,7 +2,11 @@
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/GUI/Windows/SpringBoneSetupErrorWindow.cs
+++ b/Editor/GUI/Windows/SpringBoneSetupErrorWindow.cs
@@ -2,7 +2,11 @@
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/GUI/Windows/SpringBoneWindow.cs
+++ b/Editor/GUI/Windows/SpringBoneWindow.cs
@@ -2,7 +2,11 @@
 using Unity.Collections;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/SpringBoneEditorActions.cs
+++ b/Editor/SpringBoneEditorActions.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/SpringColliderEditorActions.cs
+++ b/Editor/SpringColliderEditorActions.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/Utility/FindGameObjectsWindow.cs
+++ b/Editor/Utility/FindGameObjectsWindow.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/Editor/Utility/SetObjectParentWindow.cs
+++ b/Editor/Utility/SetObjectParentWindow.cs
@@ -1,7 +1,11 @@
 ﻿using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.Localization.Editor;
+#if UNITY_2020_2_OR_NEWER
+using Localization = UnityEditor.L10n;
+#else
+using Localization = UnityEditor.Localization.Editor.Localization;
+#endif
 
 namespace Unity.Animations.SpringBones
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.springbone",
 	"displayName": "Unity Chan Spring Bone",
-	"version": "1.2.0-preview",
+	"version": "1.2.0-preview.0",
 	"unity": "2019.4",
 	"description": "Sping Bone System for lightweight secondary animations.",
 	"keywords": ["animation"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.springbone",
 	"displayName": "Unity Chan Spring Bone",
-	"version": "1.2.0-preview.0",
+	"version": "1.2.1-preview.0",
 	"unity": "2019.4",
 	"description": "Sping Bone System for lightweight secondary animations.",
 	"keywords": ["animation"],


### PR DESCRIPTION
Localization API moved in 2020.1 and 2020.2, so package has to be embedded/edited with these changes to work. Tested to work in 2020.3/2021.1.

[UnityEditor.Localization.Editor.Localization](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Localization.Editor.Localization.html) moved to [UnityEditor.L10n](https://docs.unity3d.com/2020.2/Documentation/ScriptReference/L10n.html) in 2020.2 (missing in 2020.1)

[UnityEditor.Localization.Editor.LocalizationAttribute](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Localization.Editor.LocalizationAttribute.html) moved to [UnityEditor.LocalizationAttribute](https://docs.unity3d.com/2020.1/Documentation/ScriptReference/LocalizationAttribute.html) in 2020.1