### PR TITLE
Consider model scale

### DIFF
--- a/Runtime/Colliders/SpringCapsuleCollider.cs
+++ b/Runtime/Colliders/SpringCapsuleCollider.cs
@@ -147,7 +147,7 @@ namespace Unity.Animations.SpringBones
                 endRingPoints = new Vector3[PointCount];
             }
 
-            var worldRadius = transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var worldRadius = transform.TransformVector(radius, 0f, 0f).magnitude;
 
             var startCapOrigin = transform.position;
             var endCapOrigin = transform.TransformPoint(0f, height, 0f);
@@ -221,7 +221,7 @@ namespace Unity.Animations.SpringBones
             var start = transform.position;
             var end = transform.TransformPoint(0f, height, 0f);
             var center = 0.5f * (start + end);
-            var worldRadius = 1.5f * transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var worldRadius = 1.5f * transform.TransformVector(radius, 0f, 0f).magnitude;
             var size = new Vector3(
                 Mathf.Abs(end.x - start.x) + worldRadius,
                 Mathf.Abs(end.y - start.y) + worldRadius,
@@ -259,7 +259,7 @@ namespace Unity.Animations.SpringBones
             var localContactPoint = new Vector3(originToContactPoint.x, localMoverPosition.y, originToContactPoint.z);
             var worldContactPoint = transform.TransformPoint(localContactPoint);
             var worldNormal = transform.TransformDirection(localNormal).normalized;
-            var worldRadius = transform.TransformDirection(localMoverRadius, 0f, 0f).magnitude;
+            var worldRadius = transform.TransformVector(localMoverRadius, 0f, 0f).magnitude;
             m_colliderDebugger.RecordCollision(
                 worldContactPoint,
                 worldNormal,

--- a/Runtime/Colliders/SpringPanelCollider.cs
+++ b/Runtime/Colliders/SpringPanelCollider.cs
@@ -32,14 +32,14 @@ namespace Unity.Animations.SpringBones
             }
 
             var localTailPosition = transform.InverseTransformPoint(tailPosition);
-            var localTailRadius = transform.InverseTransformDirection(tailRadius, 0f, 0f).magnitude;
+            var localTailRadius = transform.InverseTransformVector(tailRadius, 0f, 0f).magnitude;
             if (localTailPosition.z >= localTailRadius)
             {
                 return SpringBone.CollisionStatus.NoCollision;
             }
 
             var localHeadPosition = transform.InverseTransformPoint(headPosition);
-            var localLength = transform.InverseTransformDirection(length, 0f, 0f).magnitude;
+            var localLength = transform.InverseTransformVector(length, 0f, 0f).magnitude;
 
             var halfWidth = 0.5f * width;
             var halfHeight = 0.5f * height;

--- a/Runtime/Colliders/SpringSphereCollider.cs
+++ b/Runtime/Colliders/SpringSphereCollider.cs
@@ -20,7 +20,7 @@ namespace Unity.Animations.SpringBones
         {
             var localHeadPosition = transform.InverseTransformPoint(headPosition);
             var localTailPosition = transform.InverseTransformPoint(tailPosition);
-            var localTailRadius = transform.InverseTransformDirection(tailRadius, 0f, 0f).magnitude;
+            var localTailRadius = transform.InverseTransformVector(tailRadius, 0f, 0f).magnitude;
 
 #if UNITY_EDITOR
             var originalLocalTailPosition = localTailPosition;
@@ -141,7 +141,7 @@ namespace Unity.Animations.SpringBones
 
         public void DrawGizmos(Color drawColor)
         {
-            var worldRadius = transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var worldRadius = transform.TransformVector(radius, 0f, 0f).magnitude;
             // For picking
             Gizmos.color = new Color(0f, 0f, 0f, 0f);
             Gizmos.DrawWireSphere(transform.position, worldRadius);

--- a/Runtime/SpringBone.cs
+++ b/Runtime/SpringBone.cs
@@ -264,7 +264,7 @@ namespace Unity.Animations.SpringBones
         {
             var desiredPosition = currTipPos;
             var headPosition = transform.position;
-            var scaledRadius = transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var scaledRadius = transform.TransformVector(radius, 0f, 0f).magnitude;
             var hitNormal = new Vector3(0f, 0f, 1f);
 
             var hadCollision = false;
@@ -333,7 +333,7 @@ namespace Unity.Animations.SpringBones
             // Todo: this assumes a flat ground parallel to the xz plane
             var worldHeadPosition = transform.position;
             var worldTailPosition = currTipPos;
-            var worldRadius = transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var worldRadius = transform.TransformVector(radius, 0f, 0f).magnitude;
             var worldLength = (currTipPos - worldHeadPosition).magnitude;
             var groundHeight = manager.groundHeight;
             worldHeadPosition.y -= groundHeight;
@@ -432,7 +432,7 @@ namespace Unity.Animations.SpringBones
         public void DrawSpringBoneCollision()
         {
             var childPosition = ComputeChildPosition();
-            var worldRadius = transform.TransformDirection(radius, 0f, 0f).magnitude;
+            var worldRadius = transform.TransformVector(radius, 0f, 0f).magnitude;
             // For picking
             Gizmos.DrawSphere(childPosition, worldRadius);
 


### PR DESCRIPTION
Even if the model is scaled, the size of the gizmo will not be scaled. So you can't set the collision.
This change will take scale into account and fix it to work correctly.