### PR TITLE
invariant reading for csv + internal simplifcation

### DIFF
--- a/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
+++ b/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using UnityEditor;
 using UnityEngine;
 #if UNITY_2020_2_OR_NEWER

--- a/Runtime/Setup/SpringColliderImporting.cs
+++ b/Runtime/Setup/SpringColliderImporting.cs
@@ -113,9 +113,8 @@ namespace Unity.Animations.SpringBones
         private static Transform GetChildByName(Transform parent, string name)
         {
             return Enumerable.Range(0, parent.childCount)
-                .Select(index => parent.GetChild(index))
-                .Where(child => child.name == name)
-                .FirstOrDefault();
+                .Select(parent.GetChild)
+                .FirstOrDefault(child => child.name == name);
         }
 
         private static T TryToFindComponent<T>(GameObject gameObject, string name) where T : Component

--- a/Runtime/Utility/ObjectBuilding/StringQueueObjectBuilder.cs
+++ b/Runtime/Utility/ObjectBuilding/StringQueueObjectBuilder.cs
@@ -11,7 +11,7 @@ namespace Unity.Animations.SpringBones
         {
             public static float DequeueFloat(this Queue<string> queue)
             {
-                return float.Parse(queue.Dequeue());
+                return float.Parse(queue.Dequeue(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
             }
 
             public static int DequeueInt(this Queue<string> queue)
@@ -21,9 +21,9 @@ namespace Unity.Animations.SpringBones
 
             public static Vector3 DequeueVector3(this Queue<string> queue)
             {
-                var x = float.Parse(queue.Dequeue());
-                var y = float.Parse(queue.Dequeue());
-                var z = float.Parse(queue.Dequeue());
+                var x = float.Parse(queue.Dequeue(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+                var y = float.Parse(queue.Dequeue(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
+                var z = float.Parse(queue.Dequeue(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture);
                 return new Vector3(x, y, z);
             }
 

--- a/Runtime/Utility/ObjectBuilding/StringQueueObjectBuilder.cs
+++ b/Runtime/Utility/ObjectBuilding/StringQueueObjectBuilder.cs
@@ -34,10 +34,9 @@ namespace Unity.Animations.SpringBones
                 if (parentName.Length > 0)
                 {
                     var children = gameObject.GetComponentsInChildren<Transform>(true);
-                    newParent = Object.FindObjectsOfType<Transform>()
-                        .Where(item => item.name == parentName
-                            && !children.Contains(item))
-                        .FirstOrDefault();
+                    newParent = Object
+                        .FindObjectsOfType<Transform>()
+                        .FirstOrDefault(item => item.name == parentName && !children.Contains(item));
                     if (newParent == null)
                     {
                         Debug.LogError("Valid parent not found: " + parentName);
@@ -162,15 +161,15 @@ namespace Unity.Animations.SpringBones
 
             private static System.Object ParsePrimitiveType(System.Type type, string valueSource)
             {
-                var parseMethod = type.GetMethods()
-                    .Where(method => method.Name == "Parse"
-                        && method.IsStatic
-                        && method.GetParameters().Length == 1)
-                    .FirstOrDefault();
+                var parseMethodFormatProvider = type.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null,
+                    new [] { typeof(string), typeof(System.IFormatProvider) }, null);
+                if (parseMethodFormatProvider != null)
+                    return parseMethodFormatProvider.Invoke(null, new System.Object[] { valueSource, System.Globalization.CultureInfo.InvariantCulture });
+                
+                var parseMethod = type.GetMethod("Parse", BindingFlags.Public | BindingFlags.Static, null,
+                    new [] { typeof(string) }, null);
                 if (parseMethod != null)
-                {
                     return parseMethod.Invoke(null, new System.Object[] { valueSource });
-                }
 
                 Debug.LogError("Parse not found: " + type.ToString());
                 return null;
@@ -209,8 +208,7 @@ namespace Unity.Animations.SpringBones
                 if (valueMaps != null)
                 {
                     var matchingMap = valueMaps
-                        .Where(map => map.Type == type)
-                        .FirstOrDefault();
+                        .FirstOrDefault(map => map.Type == type);
                     if (matchingMap != null)
                     {
                         return matchingMap[queue.Dequeue()];

--- a/Runtime/Utility/ObjectBuilding/TypedStringToValueMap.cs
+++ b/Runtime/Utility/ObjectBuilding/TypedStringToValueMap.cs
@@ -66,7 +66,7 @@ namespace Unity.Animations.SpringBones
                 .Where(item => item.Value == value)
                 .Select(item => item.Key)
                 .FirstOrDefault();
-            return (key != null) ? key : "";
+            return key ?? "";
         }
 
         // private

--- a/Runtime/Utility/ObjectBuilding/UnityComponentStringListBuilder.cs
+++ b/Runtime/Utility/ObjectBuilding/UnityComponentStringListBuilder.cs
@@ -78,8 +78,7 @@ namespace Unity.Animations.SpringBones
             if (valueMaps != null)
             {
                 var matchingMap = valueMaps
-                    .Where(map => map.Type == type)
-                    .FirstOrDefault();
+                    .FirstOrDefault(map => map.Type == type);
                 if (matchingMap != null)
                 {
                     outputStrings.Add(matchingMap.GetKey(sourceObject));
@@ -98,14 +97,12 @@ namespace Unity.Animations.SpringBones
                     // Arrays are messy...
                     var publicMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
                     var countMethod = publicMethods
-                        .Where(method => method.Name == "GetLength")
-                        .First();
+                        .First(method => method.Name == "GetLength");
                     var itemCount = (int)countMethod.Invoke(sourceObject, new object[] { 0 });
                     var getValueMethod = publicMethods
-                        .Where(method => method.Name == "GetValue"
-                            && method.GetParameters().Count() == 1
-                            && method.GetParameters()[0].ParameterType == typeof(int))
-                        .First();
+                        .First(method => method.Name == "GetValue"
+                                         && method.GetParameters().Count() == 1
+                                         && method.GetParameters()[0].ParameterType == typeof(int));
                     var items = new List<System.Object>(itemCount);
                     for (int itemIndex = 0; itemIndex < itemCount; itemIndex++)
                     {

--- a/Runtime/Utility/TextRecordParsing.cs
+++ b/Runtime/Utility/TextRecordParsing.cs
@@ -13,8 +13,12 @@ namespace Unity.Animations.SpringBones
             get { return new string[] { "//", "#", ";" }; }
         }
 
+        private static readonly ICollection<string> BoolFalseItems = new[] { "0", "false" };
+
         public class Record
         {
+            private List<string> items;
+            
             public Record(IEnumerable<string> initialItems)
             {
                 items = initialItems.ToList();
@@ -52,8 +56,6 @@ namespace Unity.Animations.SpringBones
             {
                 return new Queue<string>(items);
             }
-
-            private List<string> items = new List<string>();
         }
 
         // レコードのアイテムを取得。存在しない場合は空の文字列を返す。
@@ -65,9 +67,8 @@ namespace Unity.Animations.SpringBones
         // レコードの数字を取得します。アイテムが空・false・0の場合はfalseを返します
         public static bool GetBool(List<string> items, int index)
         {
-            var falseItems = new List<string> { "0", "false" };
             var itemString = GetString(items, index).Trim().ToLowerInvariant();
-            return itemString.Length > 0 && !falseItems.Contains(itemString);
+            return itemString.Length > 0 && !BoolFalseItems.Contains(itemString);
         }
 
         // レコードの数字を取得します。できなかった場合はfalseを返す。
@@ -88,7 +89,7 @@ namespace Unity.Animations.SpringBones
         {
             var item = GetString(items, index);
             float newValue;
-            var succeeded = float.TryParse(item, out newValue);
+            var succeeded = float.TryParse(item, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out newValue);
             if (succeeded)
             {
                 output = newValue;
@@ -105,9 +106,9 @@ namespace Unity.Animations.SpringBones
                 float x = 0f;
                 float y = 0f;
                 float z = 0f;
-                succeeded = float.TryParse(items[startIndex], out x)
-                    && float.TryParse(items[startIndex + 1], out y)
-                    && float.TryParse(items[startIndex + 2], out z);
+                succeeded = float.TryParse(items[startIndex], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out x)
+                    && float.TryParse(items[startIndex + 1], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out y)
+                    && float.TryParse(items[startIndex + 2], System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out z);
                 if (succeeded)
                 {
                     output.Set(x, y, z);


### PR DESCRIPTION
Fundamentally this is #17 (each fixes #16) but with additions
- additional case of float in `TextRecordParsing` for consistency
- using `GetMethod` (which in context works on all relevant types `IsPrimitive` besides `IntPtr` / `UIntPtr`) instead of `GetMethods` with LINQ
- replacing `TryParse` with overloads instead of a new helper function

There are also a few unrelated internal changes listed below.

### Changed
- StringQueueObjectBuilder/TextRecordParsing Reading float data for CSV uses invariant culture (period as decimal separator) to ensure periods are used as decimal separator

### Changed (minor / semantic)
- UnityComponentStringListBuilder/StringQueueObjectBuilder: Simplified internal code using Where(del).First()/FirstOrDefault() to instead directly use delegate-consuming First/FirstOrDefault (same result, saves a layer on LINQ call)
- TextRecordParsing: Adjusted a usage of a read-only collection in a method to be private class member to avoid potentially re-generating collection for every invocation unnecessarily
- TypedStringToValueMap: replaced a ternary operator with null-coalescing
- SaveSpringBoneSetupWindow: removed unused using directive