### PR TITLE
Support for English Inspector.

### DIFF
--- a/Editor/AssmblyInfo.cs
+++ b/Editor/AssmblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using UnityEditor.Localization.Editor;
  
-[assembly: Localization]
+[assembly: UnityEditor.Localization]

--- a/Editor/GUI/Inspectors/AngleLimitsPropertyInfo.cs
+++ b/Editor/GUI/Inspectors/AngleLimitsPropertyInfo.cs
@@ -7,11 +7,13 @@ namespace Unity.Animations.SpringBones
     {
         public class AngleLimitPropertyInfo : PropertyInfo
         {
+            bool isEngLang => !EditorPrefs.GetBool("UCSB_JLM");
+
             public AngleLimitPropertyInfo(string newName, string labelText)
                 : base(newName, labelText)
             {
-                minSlider = new FloatSlider("下限", 0f, -180f);
-                maxSlider = new FloatSlider("上限", 0f, 180f);
+                minSlider = new FloatSlider(isEngLang ? "Minimum Limit" : "下限", 0f, -180f);
+                maxSlider = new FloatSlider(isEngLang ? "Maximum Limit" : "上限", 0f, 180f);
             }
 
             public override void Show()
@@ -50,7 +52,7 @@ namespace Unity.Animations.SpringBones
                     GUILayout.Space(SubSpacing);
                     GUILayout.BeginHorizontal();
 
-                    updateValuesTogether = GUILayout.Toggle(updateValuesTogether, "同時に変更");
+                    updateValuesTogether = GUILayout.Toggle(updateValuesTogether, isEngLang ? "Sync Limit" : "同時に変更");
                     if (updateValuesTogether)
                     {
                         if (minChanged)
@@ -63,17 +65,17 @@ namespace Unity.Animations.SpringBones
                         }
                     }
 
-                    if (GUILayout.Button("下限に統一"))
+                    if (GUILayout.Button(isEngLang ? "Minimum" : "下限に統一"))
                     {
                         maxProperty.floatValue = -minProperty.floatValue;
                     }
 
-                    if (GUILayout.Button("上限に統一"))
+                    if (GUILayout.Button(isEngLang ? "Maximum" : "上限に統一"))
                     {
                         minProperty.floatValue = -maxProperty.floatValue;
                     }
 
-                    if (GUILayout.Button("反転"))
+                    if (GUILayout.Button(isEngLang ? "Flip" : "反転"))
                     {
                         var minValue = minProperty.floatValue;
                         minProperty.floatValue = -maxProperty.floatValue;

--- a/Editor/GUI/Inspectors/SpringBoneInspector.cs
+++ b/Editor/GUI/Inspectors/SpringBoneInspector.cs
@@ -13,6 +13,8 @@ namespace Unity.Animations.SpringBones
     [CanEditMultipleObjects]
     public class SpringBoneInspector : Editor
     {
+        bool isEngLang => !EditorPrefs.GetBool("UCSB_JLM");
+
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
@@ -21,7 +23,7 @@ namespace Unity.Animations.SpringBones
 
             var bone = (SpringBone)target;
 
-            if (GUILayout.Button("基点を選択", SpringBoneGUIStyles.ButtonStyle))
+            if (GUILayout.Button(isEngLang ? "Select Base Point" : "基点を選択", SpringBoneGUIStyles.ButtonStyle))
             {
                 Selection.objects = targets
                     .Select(item => ((SpringBone)item).pivotNode)
@@ -34,9 +36,9 @@ namespace Unity.Animations.SpringBones
             var managerCount = managers.Length;
             for (int managerIndex = 0; managerIndex < managerCount; managerIndex++)
             {
-                EditorGUILayout.ObjectField("マネージャー", managers[managerIndex], typeof(SpringManager), true);
+                EditorGUILayout.ObjectField(isEngLang ? "Manager" : "マネージャー", managers[managerIndex], typeof(SpringManager), true);
             }
-            var newEnabled = EditorGUILayout.Toggle("有効", bone.enabled);
+            var newEnabled = EditorGUILayout.Toggle(isEngLang ? "Enabled" : "有効", bone.enabled);
             GUILayout.EndVertical();
 
             if (newEnabled != bone.enabled)
@@ -68,7 +70,7 @@ namespace Unity.Animations.SpringBones
                 RenderAngleLimitVisualization();
             }
 
-            showOriginalInspector = EditorGUILayout.Toggle("標準インスペクター表示", showOriginalInspector);
+            showOriginalInspector = EditorGUILayout.Toggle(isEngLang ? "Default Inspector View" : "標準インスペクター表示", showOriginalInspector);
             GUILayout.Space(Spacing);
             if (showOriginalInspector)
             {
@@ -134,8 +136,8 @@ namespace Unity.Animations.SpringBones
             
             GUILayout.BeginVertical("box");
             GUILayout.BeginHorizontal();
-            GUILayout.Label("Y 軸角度制限");
-            GUILayout.Label("Z 軸角度制限");
+            GUILayout.Label(isEngLang ? "Y Axis Angle Limit" : "Y 軸角度制限");
+            GUILayout.Label(isEngLang ? "Z Axis Angle Limit" : "Z 軸角度制限");
             GUILayout.EndHorizontal();
             EditorGUILayout.Space();
             const float DefaultRectHeight = 100f;
@@ -230,35 +232,35 @@ namespace Unity.Animations.SpringBones
             InitializeData();
 
             var forceProperties = new PropertyInfo[] {
-                new PropertyInfo("stiffnessForce", "硬さ"),
-                new PropertyInfo("dragForce", "空気抵抗"),
-                new PropertyInfo("springForce", "重力"),
-                new PropertyInfo("windInfluence", "風の影響値")
+                new PropertyInfo("stiffnessForce", isEngLang ? "Stiffness" : "硬さ"),
+                new PropertyInfo("dragForce", isEngLang ? "Drag" : "空気抵抗"),
+                new PropertyInfo("springForce", isEngLang ? "Gravity" : "重力"),
+                new PropertyInfo("windInfluence", isEngLang ? "Wind Influence" : "風の影響値")
             };
 
             var angleLimitProperties = new PropertyInfo[] {
-                new PropertyInfo("pivotNode", "基点"),
-                new PropertyInfo("angularStiffness", "回転の硬さ"),
-                new AngleLimitPropertyInfo("yAngleLimits", "Y 軸角度制限"),
-                new AngleLimitPropertyInfo("zAngleLimits", "Z 軸角度制限")
+                new PropertyInfo("pivotNode", isEngLang ? "Base Pivot" : "基点"),
+                new PropertyInfo("angularStiffness", isEngLang ? "Angular Stiffness" : "回転の硬さ"),
+                new AngleLimitPropertyInfo("yAngleLimits", isEngLang ? "Y Axis Angle Limit" : "Y 軸角度制限"),
+                new AngleLimitPropertyInfo("zAngleLimits", isEngLang ? "Z Axis Angle Limit" : "Z 軸角度制限")
             };
 
             var lengthLimitProperties = new PropertyInfo[] {
-                new PropertyInfo("lengthLimitTargets", "ターゲット")
+                new PropertyInfo("lengthLimitTargets", isEngLang ? "Targets" : "ターゲット")
             };
 
             var collisionProperties = new PropertyInfo[] {
-                new PropertyInfo("radius", "半径"),
-                new PropertyInfo("sphereColliders", "球体"),
-                new PropertyInfo("capsuleColliders", "カプセル"),
-                new PropertyInfo("panelColliders", "板")
+                new PropertyInfo("radius", isEngLang ? "Radius" : "半径"),
+                new PropertyInfo("sphereColliders", isEngLang ? "Sphere Colliders" : "球体"),
+                new PropertyInfo("capsuleColliders", isEngLang ? "Capsule Colliders" : "カプセル"),
+                new PropertyInfo("panelColliders", isEngLang ? "Panel Colliders" : "板")
             };
 
             propertySets = new PropertySet[] {
-                new PropertySet("力", forceProperties), 
-                new PropertySet("角度制限", angleLimitProperties),
-                new PropertySet("距離制限", lengthLimitProperties),
-                new PropertySet("当たり判定", collisionProperties),
+                new PropertySet(isEngLang ? "Force" : "力", forceProperties), 
+                new PropertySet(isEngLang ? "Angle Limit" : "角度制限", angleLimitProperties),
+                new PropertySet(isEngLang ? "Length Limit" : "距離制限", lengthLimitProperties),
+                new PropertySet(isEngLang ? "Collision" : "当たり判定", collisionProperties),
             };
 
             foreach (var set in propertySets)

--- a/Editor/GUI/Inspectors/SpringBonePivotInspector.cs
+++ b/Editor/GUI/Inspectors/SpringBonePivotInspector.cs
@@ -9,11 +9,13 @@ namespace Unity.Animations.SpringBones
     [CanEditMultipleObjects]
     public class SpringBonePivotInspector : Editor
     {
+        bool isEngLang => !EditorPrefs.GetBool("UCSB_JLM");
+
         public override void OnInspectorGUI()
         {
             InitializeData();
 
-            if (GUILayout.Button("ボーンを選択", SpringBoneGUIStyles.ButtonStyle))
+            if (GUILayout.Button(isEngLang ? "Select bone" : "ボーンを選択", SpringBoneGUIStyles.ButtonStyle))
             {
                 Selection.objects = bones.Select(bone => bone.gameObject).ToArray();
             }

--- a/Editor/GUI/Inspectors/SpringManagerInspector.cs
+++ b/Editor/GUI/Inspectors/SpringManagerInspector.cs
@@ -10,6 +10,8 @@ namespace Unity.Animations.SpringBones
     [CanEditMultipleObjects]
     public class SpringManagerInspector : Editor
     {
+        bool isEngLang => !EditorPrefs.GetBool("UCSB_JLM");
+
         public class InspectorButton<T>
         {
             public InspectorButton(string label, System.Action<T> onPress)
@@ -35,9 +37,9 @@ namespace Unity.Animations.SpringBones
                 if (actionButtons == null || actionButtons.Length == 0)
                 {
                     actionButtons = new[] {
-                        new SpringManagerButton("窓を表示", ShowSpringWindow),
-                        new SpringManagerButton("SpringBoneを全て選択", SelectAllBones),
-                        new SpringManagerButton("SpringBoneリストを更新", UpdateBoneList)
+                        new SpringManagerButton(isEngLang ? "Display Spring Window" : "窓を表示", ShowSpringWindow),
+                        new SpringManagerButton(isEngLang ? "Select All SpringBone" : "SpringBoneを全て選択", SelectAllBones),
+                        new SpringManagerButton(isEngLang ? "Update SpringBone List" : "SpringBoneリストを更新", UpdateBoneList)
                     };
                 }
 

--- a/Editor/GUI/Windows/LoadSpringBoneSetupWindow.cs
+++ b/Editor/GUI/Windows/LoadSpringBoneSetupWindow.cs
@@ -9,14 +9,14 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("Load spring bone setup");
-            public static readonly string stopPlayModeMessage = Localization.Tr("Do not setup in Play Mode");
-            public static readonly string selectObjectRootsMessage = Localization.Tr("Select parent object of the spring bone");
-            public static readonly string resultFormat = Localization.Tr("Set up complete:{0}\nNumber of bones: {1} Number of colliders: {2}");
-            public static readonly string csvFile = Localization.Tr("CSV File");
-            public static readonly string textFile = Localization.Tr("Text File");
-            public static readonly string loadSpringBoneSetup = Localization.Tr("Load spring bone setup");
-            public static readonly string errorFormat = Localization.Tr(
+            public static readonly string editorWindowTitle = L10n.Tr("Load spring bone setup");
+            public static readonly string stopPlayModeMessage = L10n.Tr("Do not setup in Play Mode");
+            public static readonly string selectObjectRootsMessage = L10n.Tr("Select parent object of the spring bone");
+            public static readonly string resultFormat = L10n.Tr("Set up complete:{0}\nNumber of bones: {1} Number of colliders: {2}");
+            public static readonly string csvFile = L10n.Tr("CSV File");
+            public static readonly string textFile = L10n.Tr("Text File");
+            public static readonly string loadSpringBoneSetup = L10n.Tr("Load spring bone setup");
+            public static readonly string errorFormat = L10n.Tr(
                 "SpringBone setup failed.\n"
                 + "Souce data may contain errors,\n"
                 + "or the data don't match the character.\n"
@@ -26,16 +26,16 @@ namespace Unity.Animations.SpringBones
                 + "\n"
                 + "Path: {1}");
 
-            public static readonly string springBoneSetup = Localization.Tr("SpringBone Setup");
-            public static readonly string springBoneSetupFailedFormat = Localization.Tr("SpringBone Setup failed:{0}\nPath:{1}");
-            public static readonly string labelSpringBoneRoot = Localization.Tr("SpringBone Root");
+            public static readonly string springBoneSetup = L10n.Tr("SpringBone Setup");
+            public static readonly string springBoneSetupFailedFormat = L10n.Tr("SpringBone Setup failed:{0}\nPath:{1}");
+            public static readonly string labelSpringBoneRoot = L10n.Tr("SpringBone Root");
             
-            public static readonly GUIContent labelLoadingConfig = new GUIContent(Localization.Tr("Loading Configuration"));
-            public static readonly GUIContent labelSpringBone = new GUIContent(Localization.Tr("SpringBone"));
-            public static readonly GUIContent labelCollider = new GUIContent(Localization.Tr("Collider"));
+            public static readonly GUIContent labelLoadingConfig = new GUIContent(L10n.Tr("Loading Configuration"));
+            public static readonly GUIContent labelSpringBone = new GUIContent(L10n.Tr("SpringBone"));
+            public static readonly GUIContent labelCollider = new GUIContent(L10n.Tr("Collider"));
             
-            public static readonly GUIContent labelSelectFromRoot = new GUIContent(Localization.Tr("Get root from selection"));
-            public static readonly GUIContent labelSetupLoadCSV = new GUIContent(Localization.Tr("Set up from CSV file"));
+            public static readonly GUIContent labelSelectFromRoot = new GUIContent(L10n.Tr("Get root from selection"));
+            public static readonly GUIContent labelSetupLoadCSV = new GUIContent(L10n.Tr("Set up from CSV file"));
         }
 
         public static void ShowWindow()

--- a/Editor/GUI/Windows/MirrorSpringBoneWindow.cs
+++ b/Editor/GUI/Windows/MirrorSpringBoneWindow.cs
@@ -11,18 +11,18 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("SpringBone Mirror");
+            public static readonly string editorWindowTitle = L10n.Tr("SpringBone Mirror");
             
-            public static readonly GUIContent labelDoMirror = new GUIContent(Localization.Tr("Do Mirror"));
-            public static readonly GUIContent labelGetFromSelection = new GUIContent(Localization.Tr("Get from selection"));
+            public static readonly GUIContent labelDoMirror = new GUIContent(L10n.Tr("Do Mirror"));
+            public static readonly GUIContent labelGetFromSelection = new GUIContent(L10n.Tr("Get from selection"));
 
-            public static readonly GUIContent labelSelectAllCopyDst = new GUIContent(Localization.Tr("Select all copy destination"));
-            public static readonly GUIContent labelSelectAllCopySrc = new GUIContent(Localization.Tr("Select all copy source"));
-            public static readonly GUIContent labelSelectAll = new GUIContent(Localization.Tr("Select All"));
-            public static readonly GUIContent labelConfigXbZero = new GUIContent(Localization.Tr("Set bone where X > 0"));
-            public static readonly GUIContent labelConfigXlZero = new GUIContent(Localization.Tr("Set bone where X < 0"));
-            public static readonly GUIContent labelSrc = new GUIContent(Localization.Tr("Source"));
-            public static readonly GUIContent labelDst = new GUIContent(Localization.Tr("→ Destination"));
+            public static readonly GUIContent labelSelectAllCopyDst = new GUIContent(L10n.Tr("Select all copy destination"));
+            public static readonly GUIContent labelSelectAllCopySrc = new GUIContent(L10n.Tr("Select all copy source"));
+            public static readonly GUIContent labelSelectAll = new GUIContent(L10n.Tr("Select All"));
+            public static readonly GUIContent labelConfigXbZero = new GUIContent(L10n.Tr("Set bone where X > 0"));
+            public static readonly GUIContent labelConfigXlZero = new GUIContent(L10n.Tr("Set bone where X < 0"));
+            public static readonly GUIContent labelSrc = new GUIContent(L10n.Tr("Source"));
+            public static readonly GUIContent labelDst = new GUIContent(L10n.Tr("→ Destination"));
         }
 
         public static void ShowWindow()

--- a/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
+++ b/Editor/GUI/Windows/SaveSpringBoneSetupWindow.cs
@@ -10,20 +10,20 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("Save SpringBone Setup");
-            public static readonly string textSpringBoneRoot = Localization.Tr("SpringBone Root");
-            public static readonly string textSaveSpringBoneSetup = Localization.Tr("Save SpringBone Setup");
-            public static readonly string textSaveSpringBone = Localization.Tr("Save SpringBone");
-            public static readonly string textFileOverwriteFormat = Localization.Tr("File already exists. Overwrite?:{0}\n\n");
-            public static readonly string textOverwrite = Localization.Tr("Overwrite");
-            public static readonly string textSavedFormat = Localization.Tr("Saved.: {0}");
-            public static readonly string textCancel = Localization.Tr("Cancel");
+            public static readonly string editorWindowTitle = L10n.Tr("Save SpringBone Setup");
+            public static readonly string textSpringBoneRoot = L10n.Tr("SpringBone Root");
+            public static readonly string textSaveSpringBoneSetup = L10n.Tr("Save SpringBone Setup");
+            public static readonly string textSaveSpringBone = L10n.Tr("Save SpringBone");
+            public static readonly string textFileOverwriteFormat = L10n.Tr("File already exists. Overwrite?:{0}\n\n");
+            public static readonly string textOverwrite = L10n.Tr("Overwrite");
+            public static readonly string textSavedFormat = L10n.Tr("Saved.: {0}");
+            public static readonly string textCancel = L10n.Tr("Cancel");
             
-            public static readonly GUIContent labelExportSetting = new GUIContent(Localization.Tr("Export Setting"));
-            public static readonly GUIContent labelSpringBone = new GUIContent(Localization.Tr("SpringBone"));
-            public static readonly GUIContent labelCollider = new GUIContent(Localization.Tr("Collider"));
-            public static readonly GUIContent labelGetRootFromSelection = new GUIContent(Localization.Tr("Get root from selection"));
-            public static readonly GUIContent labelSaveToCSV = new GUIContent(Localization.Tr("Save to CSV"));
+            public static readonly GUIContent labelExportSetting = new GUIContent(L10n.Tr("Export Setting"));
+            public static readonly GUIContent labelSpringBone = new GUIContent(L10n.Tr("SpringBone"));
+            public static readonly GUIContent labelCollider = new GUIContent(L10n.Tr("Collider"));
+            public static readonly GUIContent labelGetRootFromSelection = new GUIContent(L10n.Tr("Get root from selection"));
+            public static readonly GUIContent labelSaveToCSV = new GUIContent(L10n.Tr("Save to CSV"));
         }
 
         public static void ShowWindow()

--- a/Editor/GUI/Windows/SpringBoneSetupErrorWindow.cs
+++ b/Editor/GUI/Windows/SpringBoneSetupErrorWindow.cs
@@ -10,15 +10,15 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("Setup Dynamics");
+            public static readonly string editorWindowTitle = L10n.Tr("Setup Dynamics");
             
-            public static readonly GUIContent labelAskDynamicError = new GUIContent(Localization.Tr("There are errors in dynamics setup. Do you want to create only ones without error(s)?"));
-            public static readonly GUIContent labelSpringBoneRoot = new GUIContent(Localization.Tr("SpringBone Root"));
-            public static readonly GUIContent labelColliderRoot = new GUIContent(Localization.Tr("Collider Root"));
-            public static readonly GUIContent labelPath = new GUIContent(Localization.Tr("Path"));
-            public static readonly GUIContent labelCreate = new GUIContent(Localization.Tr("Create"));
-            public static readonly GUIContent labelCancel = new GUIContent(Localization.Tr("Cancel"));
-            public static readonly GUIContent labelError = new GUIContent(Localization.Tr("Error"));
+            public static readonly GUIContent labelAskDynamicError = new GUIContent(L10n.Tr("There are errors in dynamics setup. Do you want to create only ones without error(s)?"));
+            public static readonly GUIContent labelSpringBoneRoot = new GUIContent(L10n.Tr("SpringBone Root"));
+            public static readonly GUIContent labelColliderRoot = new GUIContent(L10n.Tr("Collider Root"));
+            public static readonly GUIContent labelPath = new GUIContent(L10n.Tr("Path"));
+            public static readonly GUIContent labelCreate = new GUIContent(L10n.Tr("Create"));
+            public static readonly GUIContent labelCancel = new GUIContent(L10n.Tr("Cancel"));
+            public static readonly GUIContent labelError = new GUIContent(L10n.Tr("Error"));
         }
 
         public interface IConfirmAction

--- a/Editor/GUI/Windows/SpringBoneWindow.cs
+++ b/Editor/GUI/Windows/SpringBoneWindow.cs
@@ -10,36 +10,36 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("SpringBone");
+            public static readonly string editorWindowTitle = L10n.Tr("SpringBone");
 
-            public static readonly string logIconLoadFailedFormat = Localization.Tr("Icon load failed:\nPath:{0}");
-            public static readonly string logIconDirNotFound = Localization.Tr("SpringBoneWindow icon directory not found");
+            public static readonly string logIconLoadFailedFormat = L10n.Tr("Icon load failed:\nPath:{0}");
+            public static readonly string logIconDirNotFound = L10n.Tr("SpringBoneWindow icon directory not found");
             
-            public static readonly string labelDynamicCSV = Localization.Tr("Dynamics CSV");
-            public static readonly string labelLoad = Localization.Tr("Load");
-            public static readonly string labelSave = Localization.Tr("Save");
-            public static readonly string labelSpringBone = (Localization.Tr("SpringBone"));
-            public static readonly string labelSpringBoneAdd = (Localization.Tr("Add\nSpringBone"));
-            public static readonly string labelCreateOrigin = (Localization.Tr("Create Origin"));
-            public static readonly string labelCreateManager = (Localization.Tr("Create or Update Manager"));
-            public static readonly string labelMirrorBone = (Localization.Tr("Mirror SpringBones"));
-            public static readonly string labelSelectOneAndChild = (Localization.Tr("Select this and child bones"));
-            public static readonly string labelDeleteBone = (Localization.Tr("Delete SpringBone"));
-            public static readonly string labelDeleteBoneAndManager = (Localization.Tr("Delete Managers and Bones of Selection and Children"));
-            public static readonly string labelCollision = (Localization.Tr("Collision"));
-            public static readonly string labelSphere = (Localization.Tr("Sphere"));
-            public static readonly string labelCapsule = (Localization.Tr("Capsule"));
-            public static readonly string labelQuad = (Localization.Tr("Quad"));
-            public static readonly string labelFitCapsulePos = (Localization.Tr("Fit capsule place to parent"));
-            public static readonly string labelExcludeCollisionFromBone = (Localization.Tr("Exclude collision from SpringBone"));
-            public static readonly string labelDeleteCollier = (Localization.Tr("Delete collider of selection and children"));
-            public static readonly string labelCleanup = (Localization.Tr("Cleanup"));
-            public static readonly string labelShow = (Localization.Tr("Show"));
+            public static readonly string labelDynamicCSV = L10n.Tr("Dynamics CSV");
+            public static readonly string labelLoad = L10n.Tr("Load");
+            public static readonly string labelSave = L10n.Tr("Save");
+            public static readonly string labelSpringBone = (L10n.Tr("SpringBone"));
+            public static readonly string labelSpringBoneAdd = (L10n.Tr("Add\nSpringBone"));
+            public static readonly string labelCreateOrigin = (L10n.Tr("Create Origin"));
+            public static readonly string labelCreateManager = (L10n.Tr("Create or Update Manager"));
+            public static readonly string labelMirrorBone = (L10n.Tr("Mirror SpringBones"));
+            public static readonly string labelSelectOneAndChild = (L10n.Tr("Select this and child bones"));
+            public static readonly string labelDeleteBone = (L10n.Tr("Delete SpringBone"));
+            public static readonly string labelDeleteBoneAndManager = (L10n.Tr("Delete Managers and Bones of Selection and Children"));
+            public static readonly string labelCollision = (L10n.Tr("Collision"));
+            public static readonly string labelSphere = (L10n.Tr("Sphere"));
+            public static readonly string labelCapsule = (L10n.Tr("Capsule"));
+            public static readonly string labelQuad = (L10n.Tr("Quad"));
+            public static readonly string labelFitCapsulePos = (L10n.Tr("Fit capsule place to parent"));
+            public static readonly string labelExcludeCollisionFromBone = (L10n.Tr("Exclude collision from SpringBone"));
+            public static readonly string labelDeleteCollier = (L10n.Tr("Delete collider of selection and children"));
+            public static readonly string labelCleanup = (L10n.Tr("Cleanup"));
+            public static readonly string labelShow = (L10n.Tr("Show"));
             
-            public static readonly string labelShowOnlySelectedBones = (Localization.Tr("Show only selected bones"));
-            public static readonly string labelShowBoneCollision = (Localization.Tr("Show bone collisions"));
-            public static readonly string labelShowOnlySelectedCollider = (Localization.Tr("Show only selected colliders"));
-            public static readonly string labelShowBoneName = (Localization.Tr("Show bone names"));
+            public static readonly string labelShowOnlySelectedBones = (L10n.Tr("Show only selected bones"));
+            public static readonly string labelShowBoneCollision = (L10n.Tr("Show bone collisions"));
+            public static readonly string labelShowOnlySelectedCollider = (L10n.Tr("Show only selected colliders"));
+            public static readonly string labelShowBoneName = (L10n.Tr("Show bone names"));
         }
 
         private const string kIconDirectoryPath = "Packages/com.unity.springbone/Editor/GUI/Icons"; 

--- a/Editor/SpringBoneEditorActions.cs
+++ b/Editor/SpringBoneEditorActions.cs
@@ -11,25 +11,25 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string logStopPlayMode = Localization.Tr("You must stop Playmode first.");
-            public static readonly string logSelectOneOrMoreObjects = Localization.Tr("Select one or more objects.");
-            public static readonly string logSelectOnlyOneSpringManager = Localization.Tr("Select only one SpringManager");
+            public static readonly string logStopPlayMode = L10n.Tr("You must stop Playmode first.");
+            public static readonly string logSelectOneOrMoreObjects = L10n.Tr("Select one or more objects.");
+            public static readonly string logSelectOnlyOneSpringManager = L10n.Tr("Select only one SpringManager");
 
-            public static readonly string textDelete = Localization.Tr("Delete");
-            public static readonly string textCancel = Localization.Tr("Cancel");
-            public static readonly string textUpdate = Localization.Tr("Update");
+            public static readonly string textDelete = L10n.Tr("Delete");
+            public static readonly string textCancel = L10n.Tr("Cancel");
+            public static readonly string textUpdate = L10n.Tr("Update");
             
-            public static readonly string textDeleteSpringBoneAndManager = Localization.Tr("Delete SpringBone and Manager");
-            public static readonly string textDeleteSelectedBones = Localization.Tr("Delete selected bones");
+            public static readonly string textDeleteSpringBoneAndManager = L10n.Tr("Delete SpringBone and Manager");
+            public static readonly string textDeleteSelectedBones = L10n.Tr("Delete selected bones");
             
-            public static readonly string textUpdateFromBoneList = Localization.Tr("Update from bone list");
+            public static readonly string textUpdateFromBoneList = L10n.Tr("Update from bone list");
             
-            public static readonly string textConfirmRemoveAllBoneAndManagerFormat = Localization.Tr(
+            public static readonly string textConfirmRemoveAllBoneAndManagerFormat = L10n.Tr(
                 "Do you really want to remove all\n" + 
                 "SpringBones and managers under this object?\n" +
                 "\n{0}");
             
-            public static readonly string textConfirmUpdateBonesFromListFormat = Localization.Tr(
+            public static readonly string textConfirmUpdateBonesFromListFormat = L10n.Tr(
                 "Do you want to update secondary bones from bone list?\n" +
                     "\nThis will remove all SpringBones that are not listed,\n" +
                     "and will add SpringBones missing in model.\n" +

--- a/Editor/SpringColliderEditorActions.cs
+++ b/Editor/SpringColliderEditorActions.cs
@@ -11,19 +11,19 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string logStopPlayMode = Localization.Tr("You must stop Playmode first.");
-            public static readonly string textAlignCapsulesToParent = Localization.Tr("Align capsules to parents");
-            public static readonly string textConfirmDeleteCollisions = Localization.Tr("Do you really want to remove collisions from selected SpringBones?");
-            public static readonly string textRemoveCollisions = Localization.Tr("Remove Collisions");
-            public static readonly string textRemove = Localization.Tr("Remove");
-            public static readonly string textCancel = Localization.Tr("Cancel");
-            public static readonly string textRemoveDuplicateComponents = Localization.Tr("Remove duplicate components");
-            public static readonly string textCleanupSpringBone = Localization.Tr("Cleanup SpringBones");
-            public static readonly string textConfirmDynamicCleanup = Localization.Tr("Do you really want to cleanup dynamics?");
-            public static readonly string textCleanupDynamics = Localization.Tr("Cleanup Dynamics");
-            public static readonly string textRemoveAllChildColliders = Localization.Tr("Remove all selected child colliders");
-            public static readonly string textConfirmRemoveAllChildColliders = Localization.Tr("Do you really want to remove all colliders from children?");
-            public static readonly string textRemoveSelectedColliders = Localization.Tr("Remove Colliders");
+            public static readonly string logStopPlayMode = L10n.Tr("You must stop Playmode first.");
+            public static readonly string textAlignCapsulesToParent = L10n.Tr("Align capsules to parents");
+            public static readonly string textConfirmDeleteCollisions = L10n.Tr("Do you really want to remove collisions from selected SpringBones?");
+            public static readonly string textRemoveCollisions = L10n.Tr("Remove Collisions");
+            public static readonly string textRemove = L10n.Tr("Remove");
+            public static readonly string textCancel = L10n.Tr("Cancel");
+            public static readonly string textRemoveDuplicateComponents = L10n.Tr("Remove duplicate components");
+            public static readonly string textCleanupSpringBone = L10n.Tr("Cleanup SpringBones");
+            public static readonly string textConfirmDynamicCleanup = L10n.Tr("Do you really want to cleanup dynamics?");
+            public static readonly string textCleanupDynamics = L10n.Tr("Cleanup Dynamics");
+            public static readonly string textRemoveAllChildColliders = L10n.Tr("Remove all selected child colliders");
+            public static readonly string textConfirmRemoveAllChildColliders = L10n.Tr("Do you really want to remove all colliders from children?");
+            public static readonly string textRemoveSelectedColliders = L10n.Tr("Remove Colliders");
         }
 
         public static IList<GameObject> CreateObjectsWithComponentBeneathSelectedObjects<T>(string suffix) where T : Component

--- a/Editor/Utility/FindGameObjectsWindow.cs
+++ b/Editor/Utility/FindGameObjectsWindow.cs
@@ -11,13 +11,13 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("Name Selector Tool");
+            public static readonly string editorWindowTitle = L10n.Tr("Name Selector Tool");
 
-            public static readonly string textName = Localization.Tr("Name");
-            public static readonly string textIgnore = Localization.Tr("Ignore");
-            public static readonly string textComponent = Localization.Tr("Component");
-            public static readonly string textSelect = Localization.Tr("Select");
-            public static readonly string textSelectingMultipleObjectFormat = Localization.Tr("Selecting {0} objects");
+            public static readonly string textName = L10n.Tr("Name");
+            public static readonly string textIgnore = L10n.Tr("Ignore");
+            public static readonly string textComponent = L10n.Tr("Component");
+            public static readonly string textSelect = L10n.Tr("Select");
+            public static readonly string textSelectingMultipleObjectFormat = L10n.Tr("Selecting {0} objects");
         }
 
         [MenuItem("Window/Animation/SpringBone/Name Selector Tool")]

--- a/Editor/Utility/LanguageSwitcher.cs
+++ b/Editor/Utility/LanguageSwitcher.cs
@@ -8,13 +8,13 @@ public class LanguageSwitcher : MonoBehaviour
     //UCSB Stands for "Unity Chan Spring Bone";
     //JLM Stands for "Japanese Language Mode";
 
-    [MenuItem("UCSB/Set Language To English")]
+    [MenuItem("Window/Animation/SpringBone/Set Language To English")]
     public static void SwitchToEnglish()
     {
         EditorPrefs.SetBool("UCSB_JLM", false);
     }
 
-    [MenuItem("UCSB/Set Language To Japanese")]
+    [MenuItem("Window/Animation/SpringBone/Set Language To Japanese")]
     public static void SwitchToJapanese()
     {
         EditorPrefs.SetBool("UCSB_JLM", true);

--- a/Editor/Utility/LanguageSwitcher.cs
+++ b/Editor/Utility/LanguageSwitcher.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+public class LanguageSwitcher : MonoBehaviour
+{
+    //UCSB Stands for "Unity Chan Spring Bone";
+    //JLM Stands for "Japanese Language Mode";
+
+    [MenuItem("UCSB/Set Language To English")]
+    public static void SwitchToEnglish()
+    {
+        EditorPrefs.SetBool("UCSB_JLM", false);
+    }
+
+    [MenuItem("UCSB/Set Language To Japanese")]
+    public static void SwitchToJapanese()
+    {
+        EditorPrefs.SetBool("UCSB_JLM", true);
+    }
+}

--- a/Editor/Utility/LanguageSwitcher.cs.meta
+++ b/Editor/Utility/LanguageSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d0c4c01fc9b28142806b284dfde6532
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility/SetObjectParentWindow.cs
+++ b/Editor/Utility/SetObjectParentWindow.cs
@@ -9,10 +9,10 @@ namespace Unity.Animations.SpringBones
     {
         private static class Styles
         {
-            public static readonly string editorWindowTitle = Localization.Tr("Parenting Tool");
+            public static readonly string editorWindowTitle = L10n.Tr("Parenting Tool");
 
-            public static readonly GUIContent labelNewParent = new GUIContent(Localization.Tr("New Parent"));
-            public static readonly GUIContent labelSetParent = new GUIContent(Localization.Tr("Set Parent"));
+            public static readonly GUIContent labelNewParent = new GUIContent(L10n.Tr("New Parent"));
+            public static readonly GUIContent labelSetParent = new GUIContent(L10n.Tr("Set Parent"));
         }
 
 


### PR DESCRIPTION
Added Support for English SpringBone and SpringBoneManager Inspector and other Inspector that displays Japanese.

Translated Using Chat-GPT (lol) and crosschecked with related Variable and Function Names.

To Switch Between English and Japanese, head to Window > Animation > SpringBone > Set Language To English/Set Language To Japanese.

English is Default.

Also Refracted Some Obsolete Class Names for Unity 2021.3.17f.